### PR TITLE
Update URL for loading mess menu

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="TAG_STATUS">status</string>
     <string name="TAG_OPENTIME">opentime</string>
     <string name="TAG_CLOSETIME">closetime</string>
-    <string name="url_mess_menu">https://wanidipak56.000webhostapp.com/t.php</string>
+    <string name="url_mess_menu">http://messedup.in/ftrzibvapv/api/t.php</string>
 
     <string name="about_us_string"><u>About Us</u></string>
     <string name="contact_us_string"><u>Need Help? Contact Us</u></string>


### PR DESCRIPTION
Changed string "url_mess_menu". Used in splash activity, menu loading fragment